### PR TITLE
Weather API with Rate Limit

### DIFF
--- a/WeatherApi/Controllers/WeatherController.cs
+++ b/WeatherApi/Controllers/WeatherController.cs
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Eventing.Reader;
+using Microsoft.AspNetCore.Mvc;
+using WeatherApi.Models;
+using WeatherApi.Services;
+
+namespace WeatherApi.Controllers
+{
+    [ApiController]
+    [Route("weather")]
+    public class WeatherController : ControllerBase
+    {
+        private readonly WeatherService _weatherService;
+
+
+        public WeatherController()
+        {
+            _weatherService = new WeatherService();
+        }
+
+        [HttpGet("today")]
+        public ActionResult<WeatherForecast> GetTodayWeather([FromQuery] string city)
+        {
+            // define rate limmit parameters for today api call 
+            var key = HttpContext.Connection.RemoteIpAddress?.ToString() + "-day" ?? "unknown";
+            RateLimit rateLimit_today = new RateLimit(5, TimeSpan.FromMinutes(1), key);
+
+            if (string.IsNullOrWhiteSpace(city))
+                return BadRequest("City parameter is required.");
+            
+            if (!rateLimit_today.IsRequestValid())
+                return StatusCode(429, "Too many requests. Please try again later.");
+
+            var weather = _weatherService.GetTodayWeather(city);
+            return Ok(weather);
+        }
+
+        [HttpGet("week")]
+        public ActionResult<List<WeatherForecast>> GetWeeklyWeather([FromQuery] string city)
+        {
+            // d
+            var key = HttpContext.Connection.RemoteIpAddress?.ToString() + "-week" ?? "unknown";
+            RateLimit rateLimit_week = new RateLimit(10, TimeSpan.FromMinutes(1), key);
+            if (string.IsNullOrWhiteSpace(city))
+                return BadRequest("City parameter is required.");
+
+            if (!rateLimit_week.IsRequestValid())
+                return StatusCode(429, "Too many requests. Please try again later.");
+
+            var weather = _weatherService.GetWeeklyWeather(city);
+            return Ok(weather);
+        }
+    }
+    
+}

--- a/WeatherApi/Models/RateLimit.cs
+++ b/WeatherApi/Models/RateLimit.cs
@@ -1,0 +1,36 @@
+using System.Collections.Concurrent;
+namespace WeatherApi.Models
+{
+  public class RateLimit
+  {
+    private static readonly ConcurrentDictionary<string, List<DateTime>> _requestLogs = new();
+    public int RequestLimit { get; set; }
+    public TimeSpan TimeWindow { get; set; }
+    public string Key { get; set; }
+
+    public RateLimit(int requestLimit, TimeSpan timeWindow, string key)
+    {
+      Key = key;
+      RequestLimit = requestLimit;
+      TimeWindow = timeWindow;
+    }
+    public bool IsRequestValid()
+    {
+      if (_requestLogs.ContainsKey(Key))
+      {
+        _requestLogs[Key].Add(DateTime.Now);
+        _requestLogs[Key].RemoveAll(r => r < DateTime.Now.AddMinutes(-TimeWindow.Minutes));
+        if (_requestLogs[Key].Count > RequestLimit)
+        {
+          return false;
+        }
+      }
+      else
+        _requestLogs.AddOrUpdate(Key, new List<DateTime> { DateTime.Now }, (k, v) => { v.Add(DateTime.Now); return v; });
+      
+      // We have not reached the maximum number of requests
+      return true;
+
+    }
+  }
+}

--- a/WeatherApi/Models/WeatherForecast.cs
+++ b/WeatherApi/Models/WeatherForecast.cs
@@ -1,0 +1,11 @@
+namespace WeatherApi.Models
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+        public string City { get; set; } = string.Empty;
+        public double TemperatureC { get; set; }
+        public double TemperatureF => 32 + (TemperatureC * 9 / 5);
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/WeatherApi/Program.cs
+++ b/WeatherApi/Program.cs
@@ -1,0 +1,18 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+app.Run();

--- a/WeatherApi/Properties/launchSettings.json
+++ b/WeatherApi/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5029",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7045;http://localhost:5029",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/WeatherApi/Services/WeatherService.cs
+++ b/WeatherApi/Services/WeatherService.cs
@@ -1,0 +1,36 @@
+using WeatherApi.Models;
+
+namespace WeatherApi.Services
+{
+    public class WeatherService
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Sunny", "Cloudy", "Rainy", "Stormy", "Snowy", "Windy", "Foggy"
+        };
+
+        private readonly Random _random = new();
+
+        public WeatherForecast GetTodayWeather(string city)
+        {
+            return new WeatherForecast
+            {
+                Date = DateTime.UtcNow,
+                City = city,
+                TemperatureC = _random.Next(-10, 35),
+                Summary = Summaries[_random.Next(Summaries.Length)]
+            };
+        }
+
+        public List<WeatherForecast> GetWeeklyWeather(string city)
+        {
+            return [.. Enumerable.Range(0, 7).Select(day => new WeatherForecast
+            {
+                Date = DateTime.UtcNow.AddDays(day),
+                City = city,
+                TemperatureC = _random.Next(-10, 35),
+                Summary = Summaries[_random.Next(Summaries.Length)]
+            })];
+        }
+    }
+}

--- a/WeatherApi/WeatherApi.csproj
+++ b/WeatherApi/WeatherApi.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/WeatherApi/WeatherApi.csproj
+++ b/WeatherApi/WeatherApi.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>

--- a/WeatherApi/WeatherApi.http
+++ b/WeatherApi/WeatherApi.http
@@ -1,0 +1,6 @@
+@WeatherApi_HostAddress = http://localhost:5029
+
+GET {{WeatherApi_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/WeatherApi/appsettings.Development.json
+++ b/WeatherApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/WeatherApi/appsettings.json
+++ b/WeatherApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/crexi.sln
+++ b/crexi.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeatherApi", "WeatherApi\WeatherApi.csproj", "{A3906CE0-E2EF-98EE-A96A-75AF48E9F4E1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A3906CE0-E2EF-98EE-A96A-75AF48E9F4E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3906CE0-E2EF-98EE-A96A-75AF48E9F4E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3906CE0-E2EF-98EE-A96A-75AF48E9F4E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3906CE0-E2EF-98EE-A96A-75AF48E9F4E1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D2E78B0A-2616-41EF-9BCE-2B83475AE084}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
1. Created Weather API to retrieve weather data using two routes; today and week. today retrieves today’s data and week retrieves the entire week data.
2. Implemented a RateLimit class where settings get initiated based on each call. 

- Utilizes `IsRequestValid` to add a history of valid requests based on the threshold defined, and remove old requests based on the window time defined
- Stores Requests inside in-memory dictionary using ip address and api name as key
